### PR TITLE
Max. amplitude histo

### DIFF
--- a/ReadRun.h
+++ b/ReadRun.h
@@ -128,7 +128,9 @@ public:
 	int* GetIntWindow(TH1F*, float, float, float, float, int);
 	void PrintChargeSpectrumWF(float, float, float = 0, float = 300, int = 1, float = 0., float = 0.);
 	TH1F* ChargeSpectrum(int, float, float, float = 0, float = 300, float = -50, float = 600, int = 750);
+	TH1F* MaxAmplitudeSpectrum(int, float, float, float = 0, float = 300, float = -50, float = 600, int = 750);	
 	void PrintChargeSpectrum(float, float, float = 0, float = 300, float = -50, float = 600, int = 750, float = 0., float = 0., int = 8);
+	void PrintMaxAmplitudeSpectrum(float, float, float = 0, float = 300, float = -50, float = 600, int = 750, float = 0., float = 0., int = 8);
 	void PrintChargeSpectrumPMT(float, float, float = 0, float = 300, float = -50, float = 600, int = 750, double = 4);
 
 	// functions for time distribution


### PR DESCRIPTION
Added a function to create a histogram storing the maximum amplitudes of the events of a channel.
I've just coppied the ChargeSpectrum function. Instead of filling the histo with the integral from windowind[1] to windowind[2], we fill it with the value of the maximum amplitude, that is stored in the bin windowind[0].
For the printing I've just coppied the PrintChargeSpectrum function, but changing the use of ChargeSpectrum for the new one MaxAmplitudeSpectrum.